### PR TITLE
✨ 게임 진행 (검증) API 

### DIFF
--- a/app/api/game.py
+++ b/app/api/game.py
@@ -11,7 +11,8 @@ Docstring for app.api.game
 """
 from fastapi import APIRouter, Request
 
-from app.services import create, session
+from app.schemas.game_setting import InputNumber
+from app.services import create, session, game
 
 
 router = APIRouter(prefix='/nbb/api/v1', tags=['GAME'])
@@ -26,3 +27,16 @@ async def game_setting(request: Request):
         'history': request.session['history']
     }
     return test
+
+"""
+### lets_play
+게임 진행 관련 로직실행
+- 유저에게 숫자 입력을 받음 : input_number -> InputNumber
+- 정답과 비교한 값을 리턴 : Verification.check_logic()
+"""
+
+@router.post('/lets_play', description='게임 진행')
+async def playing_game(request: Request, input_number: str):
+    number_obj = InputNumber(input=input_number) # 유저가 입력한 값, 숫자 4자리인지 검증
+    v = game.Verification(input_number=number_obj.input, answer=request.session['answer'])
+    return v.check_logic()

--- a/app/api/game.py
+++ b/app/api/game.py
@@ -2,11 +2,6 @@
 Docstring for app.api.game
 게임 진행을 위한 router 작성
 
-### start
-게임 시작 시, 게임 진행을 위한 초기화 설정을 한다.
-- 세션 구성
-- 랜덤 숫자 생성
-
 ** 기능 관련 로직은 services에 작성 **
 """
 from fastapi import APIRouter, Request, Depends
@@ -20,6 +15,12 @@ router = APIRouter(prefix='/nbb/api/v1', tags=['GAME'])
 
 @router.post('/start', description='게임 초기화')
 async def game_setting(request: Request):
+    """
+    ### start
+    게임 시작 시, 게임 진행을 위한 초기화 설정을 한다.
+    - 세션 구성
+    - 랜덤 숫자 생성
+    """
     number = create.create_number() # 랜덤 숫자 생성
     session.init(request.session, number) # 세션 초기화 -> 구성
     test = {
@@ -29,18 +30,19 @@ async def game_setting(request: Request):
     }
     return test
 
-"""
-### lets_play
-게임 진행 관련 로직실행
-- 유저에게 숫자 입력을 받음 : input_number -> InputNumber
-- 정답과 비교한 값을 리턴 : Verification.check_logic()
-"""
+
 
 @router.post('/lets_play', description='게임 진행')
 async def playing_game(
     input_num: InputNumber, # 유저가 입력한 값이 숫자인지 검증
     session_data: SessionDataGroup = Depends(get_session_data) # 의존성 부여, Sessiondata 불러오는 함수 먼저 실행
     ):
+    """
+    ### lets_play
+    게임 진행 관련 로직실행
+    - 유저에게 숫자 입력을 받음 : input_number -> InputNumber
+    - 정답과 비교한 값을 리턴 : Verification.check_logic()
+    """
     v = game.Verification( # 비교 로직
         input_number=input_num.input, # 유저가 입력한 검증된 데이터 값
         answer=session_data.answer # 세션에 저장되어있는 정답을 가져옴

--- a/app/api/game.py
+++ b/app/api/game.py
@@ -9,8 +9,9 @@ Docstring for app.api.game
 
 ** 기능 관련 로직은 services에 작성 **
 """
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 
+from app.core.session import SessionDataGroup, get_session_data
 from app.schemas.game_setting import InputNumber
 from app.services import create, session, game
 
@@ -36,7 +37,12 @@ async def game_setting(request: Request):
 """
 
 @router.post('/lets_play', description='게임 진행')
-async def playing_game(request: Request, input_number: str):
-    number_obj = InputNumber(input=input_number) # 유저가 입력한 값, 숫자 4자리인지 검증
-    v = game.Verification(input_number=number_obj.input, answer=request.session['answer'])
-    return v.check_logic()
+async def playing_game(
+    input_num: InputNumber, # 유저가 입력한 값이 숫자인지 검증
+    session_data: SessionDataGroup = Depends(get_session_data) # 의존성 부여, Sessiondata 불러오는 함수 먼저 실행
+    ):
+    v = game.Verification( # 비교 로직
+        input_number=input_num.input, # 유저가 입력한 검증된 데이터 값
+        answer=session_data.answer # 세션에 저장되어있는 정답을 가져옴
+        )
+    return v.check_logic() # 로직 확인 후 결과 값 리턴

--- a/app/api/test_router.py
+++ b/app/api/test_router.py
@@ -1,0 +1,18 @@
+"""
+Docstring for app.api.test_router
+API test 진행하기 위한 Session Setting
+"""
+from fastapi import APIRouter, Request
+
+from app.services import session
+
+router = APIRouter(prefix='/__test__')
+
+@router.post('/session/mock')
+def set_session(request: Request):
+    """
+    Docstring for set_session
+    API test를 위한 세션에 데이터 저장
+    """
+    session.init(request.session, number='0987')
+    return {'Are YOU Ready?': 'Yes!'}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,8 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
+    ENV : str = 'local' # 실행환경 구분 (로컬, 테스트, 은양 베포 등 ...)
+
     SESSION_KEY : str
 
     model_config = SettingsConfigDict(

--- a/app/core/session.py
+++ b/app/core/session.py
@@ -1,0 +1,35 @@
+"""
+Docstring for app.api.session
+Session에 저장되어있는 데이터 관리 로직 작성
+
+"""
+from fastapi import Request
+
+from app.schemas.game_setting import SessionData
+
+class SessionDataGroup:
+    """
+    Docstring for SessionDataGroup
+    세션에 저장되어있는 데이터 객체화를 위한 class 정의
+    """
+    def __init__(self, request: Request):
+        data = SessionData(**request.session) # 세션 불러오기
+
+        # 변수에 데이터 할당
+        self.answer = data.answer
+        self.count = data.count
+        self.history = data.history
+
+def get_session_data(request: Request) -> SessionDataGroup:
+    """
+    Docstring for get_session_data
+    SessionDataGrop 객체화를 위한 함수
+    ex)
+    Depends(get_session_data)
+
+    :param request: Description
+    :type request: Request
+    :return: Description
+    :rtype: SessionDataGroup
+    """
+    return SessionDataGroup(request)

--- a/app/core/session.py
+++ b/app/core/session.py
@@ -45,8 +45,8 @@ class SessionUpdate:
         self.org = get_session_data(request)
         self.session = request.session
 
-    def update_history(self, input_data: str):
-        data = {self.org.count + 1: input_data}
+    def update_history(self, input_data: dict):
+        data = {str(self.org.count + 1): input_data}
         self.session['history'].append(data)
         return self.session['history']
 

--- a/app/core/session.py
+++ b/app/core/session.py
@@ -1,5 +1,5 @@
 """
-Docstring for app.api.session
+Docstring for app.core.session
 Session에 저장되어있는 데이터 관리 로직 작성
 
 """
@@ -33,3 +33,23 @@ def get_session_data(request: Request) -> SessionDataGroup:
     :rtype: SessionDataGroup
     """
     return SessionDataGroup(request)
+
+class SessionUpdate:
+    """
+    Docstring for SessionUpdate
+    게임 진행 중 업데이트 사항들을 세션에 반영
+    - update_history : 제출 이력
+    - counting : 제출 횟수
+    """
+    def __init__(self, request: Request):
+        self.org = get_session_data(request)
+        self.session = request.session
+
+    def update_history(self, input_data: str):
+        data = {self.org.count + 1: input_data}
+        self.session['history'].append(data)
+        return self.session['history']
+
+    def counting(self):
+        self.session['count'] = self.org.count + 1
+        return self.session['count']

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.api.game import router as game_router
+from app.api.test_router import router as test_router
+
 from app.core.config import settings
 
 app = FastAPI()
@@ -14,6 +16,9 @@ app.add_middleware( # SessionMiddleware 추가
 # Router
 app.include_router(game_router)
 
+# Test Router
+if settings.ENV == 'test':
+    app.include_router(test_router)
 
 @app.get("/")
 def read_root():

--- a/app/schemas/game_setting.py
+++ b/app/schemas/game_setting.py
@@ -26,3 +26,17 @@ class RandomInt(BaseModel):
         if not v.isdigit(): # 만들어진 숫자에 다른 문자열이 포함되어있는지 검증
             raise ValueError('랜덤숫자 생성 오류: 숫자가 아닌 문자열이 포함되어있습니다.')
         return v
+    
+
+class InputNumber(BaseModel):
+    input : str
+
+    @field_validator('input')
+    @classmethod
+    def is_valid_input(cls, v):
+        if not v.isdigit():
+            raise ValueError('입력 오류: 숫자만 입력해주세요.')
+        if len(v) != 4:
+            raise ValueError('입력 오류: 4자리 숫자만 입력해주세요.')
+        return v
+    

--- a/app/schemas/game_setting.py
+++ b/app/schemas/game_setting.py
@@ -1,21 +1,28 @@
 """
 Docstring for app.schemas.game_setting
 게임 세팅과 관련된 스키마 관리
-
-- answer : 정답
-- count : 시도 횟수
-- history : 제출 이력
 """
 
 from pydantic import BaseModel, field_validator
 
 class SessionData(BaseModel):
+    """
+    Docstring for SessionData
+    세션에 저장되어있는 정보
+    - answer : 정답
+    - count : 시도 횟수
+    - history : 제출 이력
+    """
     answer : str
     count : int
     history : dict[str, str]
 
 
 class RandomInt(BaseModel):
+    """
+    Docstring for RandomInt
+    랜덤으로 생성된 숫자가 문제 없이 생성 되었는지 검증
+    """
     number : str
 
     @field_validator('number')
@@ -29,6 +36,10 @@ class RandomInt(BaseModel):
     
 
 class InputNumber(BaseModel):
+    """
+    Docstring for InputNumber
+    유저가 입력한 데이터가 숫자로 구성된 4자리의 문자열인지 검증
+    """
     input : str
 
     @field_validator('input')

--- a/app/schemas/game_setting.py
+++ b/app/schemas/game_setting.py
@@ -15,7 +15,7 @@ class SessionData(BaseModel):
     """
     answer : str
     count : int
-    history : dict[str, str]
+    history : list
 
 
 class RandomInt(BaseModel):

--- a/app/schemas/response_model.py
+++ b/app/schemas/response_model.py
@@ -1,0 +1,11 @@
+"""
+Docstring for app.schemas.response_model
+API 요청 시 반환하는 Response Model을 작성
+"""
+
+from pydantic import BaseModel
+
+class GameResultResponse(BaseModel):
+    input : dict[str, str] = {'5678':'out'}
+    count : int = 2
+    history : list[dict[str, dict[str, str]]] = [{'1': {'1234': '0S2B'}}, {'2': {'5678': 'out'}}]

--- a/app/services/game.py
+++ b/app/services/game.py
@@ -1,0 +1,49 @@
+"""
+Docstring for app.services.game
+유저가 입력한 숫자 값을 검증하는 로직 작성
+
+- 정답 검증
+- strike 검증
+- ball 검증
+- 해당사항 없을 때, `out` return
+"""
+
+class Verification:
+    def __init__(self, input_number: str, answer: str):
+        self.input_number = input_number # 유저가 입력한 값
+        self.answer = answer # 정답
+        self.list_answer = list(answer)
+
+    def check_logic(self):
+        check = self._correct()
+        if check[self.input_number] == '정답':
+            return check
+        else:
+            strike = self._strike()
+            ball = self._ball()
+            if ball == 0 and strike == 0:
+                return {self.input_number: 'out'}
+            return {self.input_number: f'{strike}S{ball}B'}
+
+    def _correct(self):
+        if self.input_number == self.answer:
+            return {self.input_number: '정답'}
+        return {self.input_number: '오답'}
+
+    def _strike(self):
+        strike_count = 0
+        for i in range(4):
+            if self.input_number[i] == self.answer[i]:
+                strike_count += 1
+                self.list_answer[i] = None
+        return strike_count
+
+    def _ball(self):
+        ball_count = 0
+        for i in range(4):
+            if self.input_number[i] != self.answer[i]:
+                if self.input_number[i] in self.list_answer:
+                    ball_count += 1
+                    idx = self.list_answer.index(self.input_number[i]) ### 중복 인식 방지하기 위한 안전장치
+                    self.list_answer[idx] = None
+        return ball_count

--- a/app/services/game.py
+++ b/app/services/game.py
@@ -9,6 +9,10 @@ Docstring for app.services.game
 """
 
 class Verification:
+    """
+    Docstring for Verification
+    숫자야구 숫자 검증 로직
+    """
     def __init__(self, input_number: str, answer: str):
         self.input_number = input_number # 유저가 입력한 값
         self.answer = answer # 정답

--- a/app/services/session.py
+++ b/app/services/session.py
@@ -6,6 +6,10 @@ Docstring for app.services.session
 """
 # 세션 초기화
 def init(session: dict, number):
+    """
+    Docstring for init
+    게임 시작 시, 세션 초기화 함수
+    """
     session.clear() # 이전 게임 기록 제거
     
     session['answer'] = number # 정답

--- a/app/services/session.py
+++ b/app/services/session.py
@@ -14,5 +14,5 @@ def init(session: dict, number):
     
     session['answer'] = number # 정답
     session['count'] = 0 # 시도 횟수 카운트 초기화
-    session['history'] = {} # 답안 제출 이력 초기화 ex) '첫번째 답안': 1234
+    session['history'] = [] # 답안 제출 이력 초기화 ex) '첫번째 답안': 1234
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -671,6 +671,24 @@ pytest = ">=7"
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-env"
+version = "1.2.0"
+description = "pytest plugin that allows you to add environment variables."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00"},
+    {file = "pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80"},
+]
+
+[package.dependencies]
+pytest = ">=8.4.2"
+
+[package.extras]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.10.7)", "pytest-mock (>=3.15.1)"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -752,4 +770,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "6750ab436e9ba4d2d746f4641b13cfd6cc42093c7a10c242d7d4502462df1197"
+content-hash = "666b6a355d532dadcadaaea9f33b684b5ce909571dea3244ceee27583f64ac66"

--- a/poetry.lock
+++ b/poetry.lock
@@ -309,6 +309,103 @@ files = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.11.5"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "orjson-3.11.5-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:df9eadb2a6386d5ea2bfd81309c505e125cfc9ba2b1b99a97e60985b0b3665d1"},
+    {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc70da619744467d8f1f49a8cadae5ec7bbe054e5232d95f92ed8737f8c5870"},
+    {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073aab025294c2f6fc0807201c76fdaed86f8fc4be52c440fb78fbb759a1ac09"},
+    {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:835f26fa24ba0bb8c53ae2a9328d1706135b74ec653ed933869b74b6909e63fd"},
+    {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:667c132f1f3651c14522a119e4dd631fad98761fa960c55e8e7430bb2a1ba4ac"},
+    {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42e8961196af655bb5e63ce6c60d25e8798cd4dfbc04f4203457fa3869322c2e"},
+    {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75412ca06e20904c19170f8a24486c4e6c7887dea591ba18a1ab572f1300ee9f"},
+    {file = "orjson-3.11.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6af8680328c69e15324b5af3ae38abbfcf9cbec37b5346ebfd52339c3d7e8a18"},
+    {file = "orjson-3.11.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a86fe4ff4ea523eac8f4b57fdac319faf037d3c1be12405e6a7e86b3fbc4756a"},
+    {file = "orjson-3.11.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e607b49b1a106ee2086633167033afbd63f76f2999e9236f638b06b112b24ea7"},
+    {file = "orjson-3.11.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7339f41c244d0eea251637727f016b3d20050636695bc78345cce9029b189401"},
+    {file = "orjson-3.11.5-cp310-cp310-win32.whl", hash = "sha256:8be318da8413cdbbce77b8c5fac8d13f6eb0f0db41b30bb598631412619572e8"},
+    {file = "orjson-3.11.5-cp310-cp310-win_amd64.whl", hash = "sha256:b9f86d69ae822cabc2a0f6c099b43e8733dda788405cba2665595b7e8dd8d167"},
+    {file = "orjson-3.11.5-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9c8494625ad60a923af6b2b0bd74107146efe9b55099e20d7740d995f338fcd8"},
+    {file = "orjson-3.11.5-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:7bb2ce0b82bc9fd1168a513ddae7a857994b780b2945a8c51db4ab1c4b751ebc"},
+    {file = "orjson-3.11.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67394d3becd50b954c4ecd24ac90b5051ee7c903d167459f93e77fc6f5b4c968"},
+    {file = "orjson-3.11.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:298d2451f375e5f17b897794bcc3e7b821c0f32b4788b9bcae47ada24d7f3cf7"},
+    {file = "orjson-3.11.5-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa5e4244063db8e1d87e0f54c3f7522f14b2dc937e65d5241ef0076a096409fd"},
+    {file = "orjson-3.11.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1db2088b490761976c1b2e956d5d4e6409f3732e9d79cfa69f876c5248d1baf9"},
+    {file = "orjson-3.11.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c2ed66358f32c24e10ceea518e16eb3549e34f33a9d51f99ce23b0251776a1ef"},
+    {file = "orjson-3.11.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2021afda46c1ed64d74b555065dbd4c2558d510d8cec5ea6a53001b3e5e82a9"},
+    {file = "orjson-3.11.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b42ffbed9128e547a1647a3e50bc88ab28ae9daa61713962e0d3dd35e820c125"},
+    {file = "orjson-3.11.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:8d5f16195bb671a5dd3d1dbea758918bada8f6cc27de72bd64adfbd748770814"},
+    {file = "orjson-3.11.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c0e5d9f7a0227df2927d343a6e3859bebf9208b427c79bd31949abcc2fa32fa5"},
+    {file = "orjson-3.11.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:23d04c4543e78f724c4dfe656b3791b5f98e4c9253e13b2636f1af5d90e4a880"},
+    {file = "orjson-3.11.5-cp311-cp311-win32.whl", hash = "sha256:c404603df4865f8e0afe981aa3c4b62b406e6d06049564d58934860b62b7f91d"},
+    {file = "orjson-3.11.5-cp311-cp311-win_amd64.whl", hash = "sha256:9645ef655735a74da4990c24ffbd6894828fbfa117bc97c1edd98c282ecb52e1"},
+    {file = "orjson-3.11.5-cp311-cp311-win_arm64.whl", hash = "sha256:1cbf2735722623fcdee8e712cbaaab9e372bbcb0c7924ad711b261c2eccf4a5c"},
+    {file = "orjson-3.11.5-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:334e5b4bff9ad101237c2d799d9fd45737752929753bf4faf4b207335a416b7d"},
+    {file = "orjson-3.11.5-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:ff770589960a86eae279f5d8aa536196ebda8273a2a07db2a54e82b93bc86626"},
+    {file = "orjson-3.11.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed24250e55efbcb0b35bed7caaec8cedf858ab2f9f2201f17b8938c618c8ca6f"},
+    {file = "orjson-3.11.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a66d7769e98a08a12a139049aac2f0ca3adae989817f8c43337455fbc7669b85"},
+    {file = "orjson-3.11.5-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86cfc555bfd5794d24c6a1903e558b50644e5e68e6471d66502ce5cb5fdef3f9"},
+    {file = "orjson-3.11.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a230065027bc2a025e944f9d4714976a81e7ecfa940923283bca7bbc1f10f626"},
+    {file = "orjson-3.11.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b29d36b60e606df01959c4b982729c8845c69d1963f88686608be9ced96dbfaa"},
+    {file = "orjson-3.11.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c74099c6b230d4261fdc3169d50efc09abf38ace1a42ea2f9994b1d79153d477"},
+    {file = "orjson-3.11.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e697d06ad57dd0c7a737771d470eedc18e68dfdefcdd3b7de7f33dfda5b6212e"},
+    {file = "orjson-3.11.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e08ca8a6c851e95aaecc32bc44a5aa75d0ad26af8cdac7c77e4ed93acf3d5b69"},
+    {file = "orjson-3.11.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e8b5f96c05fce7d0218df3fdfeb962d6b8cfff7e3e20264306b46dd8b217c0f3"},
+    {file = "orjson-3.11.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ddbfdb5099b3e6ba6d6ea818f61997bb66de14b411357d24c4612cf1ebad08ca"},
+    {file = "orjson-3.11.5-cp312-cp312-win32.whl", hash = "sha256:9172578c4eb09dbfcf1657d43198de59b6cef4054de385365060ed50c458ac98"},
+    {file = "orjson-3.11.5-cp312-cp312-win_amd64.whl", hash = "sha256:2b91126e7b470ff2e75746f6f6ee32b9ab67b7a93c8ba1d15d3a0caaf16ec875"},
+    {file = "orjson-3.11.5-cp312-cp312-win_arm64.whl", hash = "sha256:acbc5fac7e06777555b0722b8ad5f574739e99ffe99467ed63da98f97f9ca0fe"},
+    {file = "orjson-3.11.5-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:3b01799262081a4c47c035dd77c1301d40f568f77cc7ec1bb7db5d63b0a01629"},
+    {file = "orjson-3.11.5-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:61de247948108484779f57a9f406e4c84d636fa5a59e411e6352484985e8a7c3"},
+    {file = "orjson-3.11.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:894aea2e63d4f24a7f04a1908307c738d0dce992e9249e744b8f4e8dd9197f39"},
+    {file = "orjson-3.11.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ddc21521598dbe369d83d4d40338e23d4101dad21dae0e79fa20465dbace019f"},
+    {file = "orjson-3.11.5-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7cce16ae2f5fb2c53c3eafdd1706cb7b6530a67cc1c17abe8ec747f5cd7c0c51"},
+    {file = "orjson-3.11.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e46c762d9f0e1cfb4ccc8515de7f349abbc95b59cb5a2bd68df5973fdef913f8"},
+    {file = "orjson-3.11.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7345c759276b798ccd6d77a87136029e71e66a8bbf2d2755cbdde1d82e78706"},
+    {file = "orjson-3.11.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75bc2e59e6a2ac1dd28901d07115abdebc4563b5b07dd612bf64260a201b1c7f"},
+    {file = "orjson-3.11.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:54aae9b654554c3b4edd61896b978568c6daa16af96fa4681c9b5babd469f863"},
+    {file = "orjson-3.11.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:4bdd8d164a871c4ec773f9de0f6fe8769c2d6727879c37a9666ba4183b7f8228"},
+    {file = "orjson-3.11.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a261fef929bcf98a60713bf5e95ad067cea16ae345d9a35034e73c3990e927d2"},
+    {file = "orjson-3.11.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c028a394c766693c5c9909dec76b24f37e6a1b91999e8d0c0d5feecbe93c3e05"},
+    {file = "orjson-3.11.5-cp313-cp313-win32.whl", hash = "sha256:2cc79aaad1dfabe1bd2d50ee09814a1253164b3da4c00a78c458d82d04b3bdef"},
+    {file = "orjson-3.11.5-cp313-cp313-win_amd64.whl", hash = "sha256:ff7877d376add4e16b274e35a3f58b7f37b362abf4aa31863dadacdd20e3a583"},
+    {file = "orjson-3.11.5-cp313-cp313-win_arm64.whl", hash = "sha256:59ac72ea775c88b163ba8d21b0177628bd015c5dd060647bbab6e22da3aad287"},
+    {file = "orjson-3.11.5-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e446a8ea0a4c366ceafc7d97067bfd55292969143b57e3c846d87fc701e797a0"},
+    {file = "orjson-3.11.5-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:53deb5addae9c22bbe3739298f5f2196afa881ea75944e7720681c7080909a81"},
+    {file = "orjson-3.11.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82cd00d49d6063d2b8791da5d4f9d20539c5951f965e45ccf4e96d33505ce68f"},
+    {file = "orjson-3.11.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fd15f9fc8c203aeceff4fda211157fad114dde66e92e24097b3647a08f4ee9e"},
+    {file = "orjson-3.11.5-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9df95000fbe6777bf9820ae82ab7578e8662051bb5f83d71a28992f539d2cda7"},
+    {file = "orjson-3.11.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92a8d676748fca47ade5bc3da7430ed7767afe51b2f8100e3cd65e151c0eaceb"},
+    {file = "orjson-3.11.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aa0f513be38b40234c77975e68805506cad5d57b3dfd8fe3baa7f4f4051e15b4"},
+    {file = "orjson-3.11.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa1863e75b92891f553b7922ce4ee10ed06db061e104f2b7815de80cdcb135ad"},
+    {file = "orjson-3.11.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4be86b58e9ea262617b8ca6251a2f0d63cc132a6da4b5fcc8e0a4128782c829"},
+    {file = "orjson-3.11.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:b923c1c13fa02084eb38c9c065afd860a5cff58026813319a06949c3af5732ac"},
+    {file = "orjson-3.11.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1b6bd351202b2cd987f35a13b5e16471cf4d952b42a73c391cc537974c43ef6d"},
+    {file = "orjson-3.11.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bb150d529637d541e6af06bbe3d02f5498d628b7f98267ff87647584293ab439"},
+    {file = "orjson-3.11.5-cp314-cp314-win32.whl", hash = "sha256:9cc1e55c884921434a84a0c3dd2699eb9f92e7b441d7f53f3941079ec6ce7499"},
+    {file = "orjson-3.11.5-cp314-cp314-win_amd64.whl", hash = "sha256:a4f3cb2d874e03bc7767c8f88adaa1a9a05cecea3712649c3b58589ec7317310"},
+    {file = "orjson-3.11.5-cp314-cp314-win_arm64.whl", hash = "sha256:38b22f476c351f9a1c43e5b07d8b5a02eb24a6ab8e75f700f7d479d4568346a5"},
+    {file = "orjson-3.11.5-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1b280e2d2d284a6713b0cfec7b08918ebe57df23e3f76b27586197afca3cb1e9"},
+    {file = "orjson-3.11.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c8d8a112b274fae8c5f0f01954cb0480137072c271f3f4958127b010dfefaec"},
+    {file = "orjson-3.11.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f0a2ae6f09ac7bd47d2d5a5305c1d9ed08ac057cda55bb0a49fa506f0d2da00"},
+    {file = "orjson-3.11.5-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0d87bd1896faac0d10b4f849016db81a63e4ec5df38757ffae84d45ab38aa71"},
+    {file = "orjson-3.11.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:801a821e8e6099b8c459ac7540b3c32dba6013437c57fdcaec205b169754f38c"},
+    {file = "orjson-3.11.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69a0f6ac618c98c74b7fbc8c0172ba86f9e01dbf9f62aa0b1776c2231a7bffe5"},
+    {file = "orjson-3.11.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fea7339bdd22e6f1060c55ac31b6a755d86a5b2ad3657f2669ec243f8e3b2bdb"},
+    {file = "orjson-3.11.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4dad582bc93cef8f26513e12771e76385a7e6187fd713157e971c784112aad56"},
+    {file = "orjson-3.11.5-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:0522003e9f7fba91982e83a97fec0708f5a714c96c4209db7104e6b9d132f111"},
+    {file = "orjson-3.11.5-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:7403851e430a478440ecc1258bcbacbfbd8175f9ac1e39031a7121dd0de05ff8"},
+    {file = "orjson-3.11.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5f691263425d3177977c8d1dd896cde7b98d93cbf390b2544a090675e83a6a0a"},
+    {file = "orjson-3.11.5-cp39-cp39-win32.whl", hash = "sha256:61026196a1c4b968e1b1e540563e277843082e9e97d78afa03eb89315af531f1"},
+    {file = "orjson-3.11.5-cp39-cp39-win_amd64.whl", hash = "sha256:09b94b947ac08586af635ef922d69dc9bc63321527a3a04647f4986a73f4bd30"},
+    {file = "orjson-3.11.5.tar.gz", hash = "sha256:82393ab47b4fe44ffd0a7659fa9cfaacc717eb617c93cde83795f14af5c2e9d5"},
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -655,4 +752,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "6f12f60ad247962dcea8bda41161971c83b5ad31b5738d1216eb9afda9d304d9"
+content-hash = "6750ab436e9ba4d2d746f4641b13cfd6cc42093c7a10c242d7d4502462df1197"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 pytest = "^9.0.2"
 httpx = "^0.28.1"
 pytest-cov = "^7.0.0"
+pytest-env = "^1.2.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "uvicorn (>=0.40.0,<0.41.0)",
     "pydantic (>=2.12.5,<3.0.0)",
     "pydantic-settings (>=2.12.0,<3.0.0)",
-    "itsdangerous (>=2.2.0,<3.0.0)"
+    "itsdangerous (>=2.2.0,<3.0.0)",
+    "orjson (>=3.11.5,<4.0.0)"
 ]
 
 [tool.poetry]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+env =
+    ENV=test
+pythonpath = .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+@pytest.fixture
+def client():
+    """
+    Docstring for client
+    client를 fixture로 설정
+    """
+    return TestClient(app)
+
+@pytest.fixture
+def session_data_set_up(client):
+    client.post('/__test__/session/mock')
+    return client

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -7,10 +7,10 @@ from app.services.create import create_number
 from app.services.game import Verification
 from app.schemas.game_setting import RandomInt
 
-client = TestClient(app)
+# client = TestClient(app)
 
 # 게임 시작 시, 초기화 test
-def test_game_setting(): # API test / session 생성 확인
+def test_game_setting(client): # API test / session 생성 확인
     response = client.post('/nbb/api/v1/start')
     assert response.status_code == 200 # 초기화 성공
 
@@ -64,3 +64,29 @@ class TestVerification:
     def test_success_case_5(self):
         v = Verification(input_number='0909', answer='1234')
         assert v.check_logic()['0909'] == 'out'
+
+
+
+# 숫자야구 검증 로직 API test `/lets_play`
+def test_playgame(session_data_set_up):
+    response = session_data_set_up.post('/nbb/api/v1/lets_play', json={'input': '1234'})
+
+    assert response.status_code == 200 # 상태코드 확인
+
+    data = response.json() # 데이터 객체화
+    check_history = data['history']
+    assert len(check_history) == 1
+    assert data['count'] == 1
+    assert check_history[0] == {'1': {'1234': 'out'}}
+
+def test_playgame_failcase_1(session_data_set_up):
+    """
+    Docstring for test_playgame_failcase
+    잘못된 값 입력 : 입력된 숫자가 4자리가 아닌 경우
+    """
+    response = session_data_set_up.post('/nbb/api/v1/lets_play', json={'input': '123'})
+    assert response.status_code == 422
+
+def test_playgame_failcase_2(session_data_set_up):
+    response = session_data_set_up.post('/nbb/api/v1/lets_play', json={'input': '테스트 중'})
+    assert response.status_code == 422

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -4,6 +4,7 @@ from pytest import raises
 
 from app.main import app
 from app.services.create import create_number
+from app.services.game import Verification
 from app.schemas.game_setting import RandomInt
 
 client = TestClient(app)
@@ -41,3 +42,25 @@ class RandomIntFailCaseTest:
     def test_randomint_fail_3():
         with raises(ValidationError):
             RandomInt(number='')
+
+# 숫자 검증 로직 test
+class TestVerification:
+    def test_success_case_1(self):
+        v = Verification(input_number='1234', answer='1234')
+        assert v.check_logic()['1234'] == '정답'
+
+    def test_success_case_2(self):
+        v = Verification(input_number='1256', answer='1234')
+        assert v.check_logic()['1256'] == '2S0B'
+
+    def test_success_case_3(self):
+        v = Verification(input_number='1243', answer='1234')
+        assert v.check_logic()['1243'] == '2S2B'
+
+    def test_success_case_4(self):
+        v = Verification(input_number='3412', answer='1234')
+        assert v.check_logic()['3412'] == '0S4B'
+    
+    def test_success_case_5(self):
+        v = Verification(input_number='0909', answer='1234')
+        assert v.check_logic()['0909'] == 'out'


### PR DESCRIPTION
## ✨ 게임 진행 (검증) API
ISSUES : #6 
게임 진행을 위한 관련 로직들을 실행 및 세션에 이력들을 저장. [POST]

- 유저에게 숫자 입력을 받음
- 정답과 비교한 값을 리턴
- 세션에 제출 이력들을 저장 (history, count)

## 🔍 모아보기
### API
- [X] 엔드 포인트 정의 : `api/game.py`

### Service
- [X] 숫자 야구 로직

### Schema (DTO)
- [X] InputNumber : 유저가 응답한 데이터가 숫자로 이루어진 문자열인지 검증 로직
- [x] GameResultResponse : 응답 모델 정의 (response_model.py)

### Test
- [X] 숫자야구 로직
- [x] API Test Cases (성공 케이스 및 실패 케이스 작성)
    - API Test를 위한 세팅 구조 변경 (conftest 및 test 전용 router 추가 등 ...)

### Core
- [X] Session Data 객체화 (handling) : class 정의 및 함수 추가
    - Session 데이터 객체화 클래스 정의
    - FastAPI 의존성 주입을 위한 세션 접근 함수 추가
- [X] Session 업데이트 : 게임 진행 상황을 세션에 업데이트

### Dependency
- Response
    - orjosn

- Test 진행 시 필요한 모듈 추가 (dev group에만 반영)
    - pytest-env

### etc
- Docstring 추가
