### PR TITLE
🐛 (Bug) : 게임 진행 API, 변수 할당 값 인식 오류

### DIFF
--- a/app/api/game.py
+++ b/app/api/game.py
@@ -56,6 +56,8 @@ async def playing_game(
 
     session_update = SessionUpdate(request)
 
+    update_status = session_data.status # 기본값 할당
+
     if result[input_num.input] == '정답':
         update_status = session_update.update_status_end()
     


### PR DESCRIPTION
ISSUE : #13 
- if문에 해당되는 케이스가 없을 경우, 상태 값이 리턴에 있는 변수에 할당이 안되는 문제
- 기본 값 할당으로 해결